### PR TITLE
Fix rendering of choices: HTML formatting and pluginfile URLs

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -70,7 +70,14 @@ class qtype_ddmatch_renderer extends qtype_with_combined_feedback_renderer {
         $question = $qa->get_question();
         $choices = array();
         foreach ($question->get_choice_order() as $key => $choiceid) {
-            $choices[$key] = format_string($question->choices[$choiceid]);;
+            $choices[$key] = $question->format_text(
+                $question->choices[$choiceid],
+                FORMAT_MOODLE,
+                $qa,
+                'qtype_ddmatch',
+                'subanswer',
+                $choiceid
+            );
         }
         return $choices;
     }


### PR DESCRIPTION
Since e526bb1a4f60512c464a9cd36128d0cda2506cd3 the rendering of HTML formatted content, including images, was broken.

This PR fixes both the formatting of rich HTML content and the conversion of all pluginfile URLs.

Before this PR:
![image](https://github.com/user-attachments/assets/4fcb1afb-32fe-49bd-8e5d-60e204dda9b9)

With this PR:
![image](https://github.com/user-attachments/assets/867749de-58fd-4bdb-bccb-84811044bd4e)

Question definition:
![image](https://github.com/user-attachments/assets/c278045f-22a5-4fd8-9a14-b71691090cb9)
