### PR TITLE
MDL-83541: Implement backup questiondata / identity functions to prevent duplication of questions on restore

### DIFF
--- a/backup/moodle2/restore_qtype_ddmatch_plugin.class.php
+++ b/backup/moodle2/restore_qtype_ddmatch_plugin.class.php
@@ -70,6 +70,57 @@ class restore_qtype_ddmatch_plugin extends restore_qtype_plugin {
     }
 
     /**
+     * Convert the backup structure of this question type into a structure matching its question data
+     *
+     * This should take the hierarchical array of tags from the question's backup structure, and return a structure that matches
+     * that returned when calling {@see get_question_options()} for this question type.
+     * See https://docs.moodle.org/dev/Question_data_structures#Representation_1:_%24questiondata for an explanation of this
+     * structure.
+     *
+     * This data will then be used to produce an identity hash for comparison with questions in the database.
+     *
+     * This base implementation deals with all common backup elements created by the add_question_*_options() methods in this class,
+     * plus elements added by ::define_question_plugin_structure() named for the qtype. The question type will need to extend
+     * this function if ::define_question_plugin_structure() adds any other elements to the backup.
+     *
+     * @param array $backupdata The hierarchical array of tags from the backup.
+     * @return \stdClass The questiondata object.
+     */
+    public static function convert_backup_to_questiondata(array $backupdata): \stdClass {
+        $questiondata = parent::convert_backup_to_questiondata($backupdata);
+
+        $questiondata->options = (object) $backupdata["plugin_qtype_ddmatch_question"]['matchoptions'][0];
+        $questiondata->options->subquestions = array_map(
+            fn($match) => (object) $match,
+            $backupdata["plugin_qtype_ddmatch_question"]['matches']['match'] ?? [],
+        );
+
+        return $questiondata;
+    }
+
+    /**
+     * Return a list of paths to fields to be removed from questiondata before creating an identity hash.
+     *
+     * Fields that should be excluded from common elements such as answers or numerical units that are used by the plugin will
+     * be excluded automatically. This method just needs to define any specific to this plugin, such as foreign keys used in the
+     * plugin's tables.
+     *
+     * The returned array should be a list of slash-delimited paths to locate the fields to be removed from the questiondata object.
+     * For example, if you want to remove the field `$questiondata->options->questionid`, the path would be '/options/questionid'.
+     * If a field in the path is an array, the rest of the path will be applied to each object in the array. So if you have
+     * `$questiondata->options->answers[]`, the path '/options/answers/id' will remove the 'id' field from each element of the
+     * 'answers' array.
+     *
+     * @return array
+     */
+    protected function define_excluded_identity_hash_fields(): array {
+        return parent::define_excluded_identity_hash_fields() + [
+            '/options/subquestions/id',
+            '/options/subquestions/questionid',
+        ];
+    }
+
+    /**
      * Process the qtype/matchoptions element.
      */
     public function process_matchoptions($data) {


### PR DESCRIPTION
This PR addresses #50 / [MDL-83541](https://tracker.moodle.org/browse/MDL-83541). For developer information see here: https://moodledev.io/docs/5.0/apis/plugintypes/qtype/restore

This PR implements the required functions so that the backup process can correctly identify identical questions and thereby prevent duplicate restores.

It makes `mod/quiz/tests/backup/repeated_restore_test.php` pass. However, please review the changes careful since I'm not familiar with the full internal data structure of ddmatch.